### PR TITLE
add description to primo silo and new url

### DIFF
--- a/src/SearchGateway/Model/LibGuidesSilo.php
+++ b/src/SearchGateway/Model/LibGuidesSilo.php
@@ -24,10 +24,11 @@ Class LibGuidesSilo extends Silo {
 
 	$request = $this->client->createRequest('GET', 'http://lgapi.libapps.com/1.1/guides');
 	$LibGuidesQuery = $request->getQuery();
-	$LibGuidesQuery['key'] = $this->key;
-	$LibGuidesQuery['site_id'] = $this->siteId;
-	$LibGuidesQuery['sort_by'] = 'relevance';
-	$LibGuidesQuery['search_terms'] = $query;
+
+	$LibGuidesQuery['key'] = $this->key; //OU specific private ky
+	$LibGuidesQuery['site_id'] = $this->siteId; //the OU site ID...could change...that's why it's set as a variable
+	$LibGuidesQuery['sort_by'] = 'relevance'; //default is by date...we want to sort by relevance
+	$LibGuidesQuery['search_terms'] = $query; //the search terms
 	$response = $this->client->send($request);
 
 	$json = $response->json();

--- a/src/SearchGateway/Model/PrimoSilo.php
+++ b/src/SearchGateway/Model/PrimoSilo.php
@@ -39,6 +39,7 @@ Class PrimoSilo extends Silo {
     $primoQuery['vid'] = $this->vid;
     $primoQuery['scope'] = 'default_scope';
     $primoQuery['addfields'] = ['pnxId'];
+    $primoQuery['view'] = 'full';
     if ($this->primoBook) {
       $primoQuery['qInclude'] = 'facet_rtype,exact,books';
     }
@@ -50,10 +51,11 @@ Class PrimoSilo extends Silo {
 
 	# Process hits
 	foreach ($primoJson['docs'] as $docs) {
+        $implodedSubs = (is_array($docs['subject'])) ? implode(' | ', $docs['subject']) : $docs['subject'];
 
 	    $my_title = $docs['title'];
-	    $my_link  = "http://ou-primo.hosted.exlibrisgroup.com/OU:default_scope:".$docs['pnxId'];
-	    $my_description  = ""; // no good source for description known
+	    $my_link  = "https://ou-primo.hosted.exlibrisgroup.com/primo-explore/fulldisplay?docid=".$docs['pnxId']."&vid=".$this->vid."";
+	    $my_description  = $implodedSubs; // no good source for description known
 
 	    $myResult->addHit($my_link, $my_title, $my_description);
 	}

--- a/src/SearchGateway/Model/PrimoSilo.php
+++ b/src/SearchGateway/Model/PrimoSilo.php
@@ -20,6 +20,7 @@ Class PrimoSilo extends Silo {
    */
   public function getResult($query, $limit) {
 
+    #only set this is it is for 'books only'
     $bookSearchArg = ($this->primoBook) ? ',AND&pfilter=pfilter,exact,books,AND&mode=advanced' : '';
 
     $myResult = new Result();
@@ -33,13 +34,15 @@ Class PrimoSilo extends Silo {
     # https://developers.exlibrisgroup.com/primo/apis/webservices/rest/pnxs
     $primoRequest = $this->client->createRequest('GET', $this->primoHost . "/primo/v1/pnxs");
     $primoQuery = $primoRequest->getQuery();
-    $primoQuery['q'] = 'any,contains,' . $query;
-    $primoQuery['limit'] = $limit;
-    $primoQuery['apikey'] = $this->primoKey;
-    $primoQuery['vid'] = $this->vid;
-    $primoQuery['scope'] = 'default_scope';
-    $primoQuery['addfields'] = ['pnxId'];
-    $primoQuery['view'] = 'full';
+    $primoQuery['q'] = 'any,contains,' . $query; //the search term
+    $primoQuery['limit'] = $limit; //number of records to return
+    $primoQuery['apikey'] = $this->primoKey; //private key for OU
+    $primoQuery['vid'] = $this->vid; //identification code...right now it is 'OUNEW'
+    $primoQuery['scope'] = 'default_scope'; //range of types to return...default is everything
+    $primoQuery['addfields'] = ['pnxId']; //specific identifier for individual records
+    $primoQuery['view'] = 'full'; //view = full will return everything...including the subject or description
+
+    #if this is 'books only' then we need to set that facet type
     if ($this->primoBook) {
       $primoQuery['qInclude'] = 'facet_rtype,exact,books';
     }
@@ -51,11 +54,13 @@ Class PrimoSilo extends Silo {
 
 	# Process hits
 	foreach ($primoJson['docs'] as $docs) {
+        #if there is more than one subject it is returned as an array
+        #if it is we separate each one by a vertical bar '|'
         $implodedSubs = (is_array($docs['subject'])) ? implode(' | ', $docs['subject']) : $docs['subject'];
 
 	    $my_title = $docs['title'];
 	    $my_link  = "https://ou-primo.hosted.exlibrisgroup.com/primo-explore/fulldisplay?docid=".$docs['pnxId']."&vid=".$this->vid."";
-	    $my_description  = $implodedSubs; // no good source for description known
+	    $my_description  = $implodedSubs;
 
 	    $myResult->addHit($my_link, $my_title, $my_description);
 	}


### PR DESCRIPTION
add description to primo silo and new url

added the ability to return a description within the primo silo
and made the search url point to the new ui in primo

Motivation and Context
----------------------
<!--- Why is this change required? What problem does it solve? -->
<!--- If it relates to an open issue or another pull request, please link to that here. -->

How Has This Been Tested?
-------------------------


