### PR TITLE
Revert to using Content Type in web results.

### DIFF
--- a/src/SearchGateway/Model/DrupalSilo.php
+++ b/src/SearchGateway/Model/DrupalSilo.php
@@ -96,19 +96,10 @@ class DrupalSilo extends Silo  {
         $sentData['my_title'] = $doc->label;
         $sentData['my_link']  = $doc->url;
         $sentData['text'] = $doc->$textField;
-        $sentData['type'] = $this->_getType($doc->bundle);
+        $sentData['type'] = $doc->bundle_name;
         $sentData['image'] = $doc->sm_picture[0];
         $myResult->addHit($sentData);
       }
     return $myResult;
   }
-
-  private function _getType( $bundle) {
-    $resultType="web page";
-    if( "event" == $bundle) {
-      $resultType = "event";
-    }
-    return $resultType;
-  }
-
 }


### PR DESCRIPTION
Reverting the collapse of Content Type labels into "web page" for Material Type. 

Motivation and Context
----------------------
We want them labeled specifically, but will use a generic web page icon. I mis-recorded the requested feature. 



