### PR TITLE
Restrict search to users with searchable set to true.

### DIFF
--- a/src/SearchGateway/Model/DrupalSilo.php
+++ b/src/SearchGateway/Model/DrupalSilo.php
@@ -69,7 +69,7 @@ class DrupalSilo extends Silo  {
 
       case "people":
         // Show only people with titles
-        $query->createFilterQuery('onlyUsers')->setQuery('+bundle:user AND ts_title:*');
+        $query->createFilterQuery('onlyUsers')->setQuery('+bundle:user AND bm_field_searchable:true');
         $myResult->full = $this->drupal_base."/search/research-specialists/".$needle;
         // HACK people results are big, so we count each one as two results 
         $limit = ceil($limit/2);


### PR DESCRIPTION
Check for `bm_field_searchable:true` when looking for people

Motivation and Context
----------------------
We only want to return certain people in the site search. 

How Has This Been Tested?
-------------------------
Works in vagrant. 
