### PR TITLE
Update teaser field precedence.

### DIFF
--- a/src/SearchGateway/Model/DrupalSilo.php
+++ b/src/SearchGateway/Model/DrupalSilo.php
@@ -105,9 +105,9 @@ class DrupalSilo extends Silo  {
       $sentData['type'] = $doc->bundle_name;
       $sentData['image'] = $doc->ss_picture;
 
-      // better teaser field defined for some content types 
-      // we'll eventuall switch to it everywhere
-      if( isset($doc->sm_field_teaser) ) {
+      // teaser field defined for some content types 
+      // we'll use our custom one, one less it's emppty and the otehr one is set. 
+      if( empty($sentData['text']) and isset($doc->sm_field_teaser) ) {
           $sentData['text'] = $doc->sm_field_teaser;
       }
 


### PR DESCRIPTION
Use `field_one_sentence_teaser` as default teaser, make `field_teaser` as a fallback. 

Motivation and Context
----------------------
We're standardizing on `field_one_sentence_teaser`. 

How Has This Been Tested?
-------------------------
Works in vagrant. 
